### PR TITLE
Feature/cmake build cleanups

### DIFF
--- a/src/sc_plugin/.gitignore
+++ b/src/sc_plugin/.gitignore
@@ -1,1 +1,2 @@
 build/
+install/

--- a/src/sc_plugin/CMakeLists.txt
+++ b/src/sc_plugin/CMakeLists.txt
@@ -34,3 +34,10 @@ target_include_directories(SuperStecker PUBLIC ${SC_SRC_PATH}/include/common)
 target_include_directories(SuperStecker PUBLIC ${SC_SRC_PATH}/common)
 
 target_link_libraries(SuperStecker PUBLIC stecker_rs)
+
+if(NOT CMAKE_INSTALL_PREFIX)
+  set(CMAKE_INSTALL_PREFIX ${PROJECT_SOURCE_DIR}/install)
+endif()
+
+install(TARGETS SuperStecker LIBRARY DESTINATION ${PROJECT_NAME})
+install(FILES src/SuperStecker.sc DESTINATION ${PROJECT_NAME}/Classes)

--- a/src/sc_plugin/CMakePresets.json
+++ b/src/sc_plugin/CMakePresets.json
@@ -1,22 +1,64 @@
 {
-    "version": 3,
+    "version": 6,
     "configurePresets": [
         {
-            "name": "macOS",
+            "name": "default",
+            "hidden": true,
+            "installDir": "install",
             "binaryDir": "${sourceDir}/build/",
-            "generator": "Xcode",
             "cacheVariables": {
                 "SC_SRC_PATH": "$env{SC_SRC_PATH}"
             }
         },
         {
+            "name": "macOS",
+            "inherits": "default",
+            "generator": "Xcode"
+        },
+        {
             "name": "Linux",
-            "binaryDir": "${sourceDir}/build/",
-            "generator": "Unix Makefiles",
-            "cacheVariables": {
-                "SC_SRC_PATH": "$env{SC_SRC_PATH}"
-            }
+            "inherits": "default",
+            "generator": "Unix Makefiles"
         }
-
+    ],
+    "buildPresets": [
+        {
+            "name": "macOS",
+            "configurePreset": "macOS",
+            "targets": ["install"]
+        },
+        {
+            "name": "Linux",
+            "configurePreset": "Linux",
+            "targets": ["install"]
+        }
+    ],
+    "workflowPresets": [
+        {
+            "name": "macOS",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "macOS"
+                },
+                {
+                    "type": "build",
+                    "name": "macOS"
+                }
+            ]
+        },
+        {
+            "name": "Linux",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "Linux"
+                },
+                {
+                    "type": "build",
+                    "name": "Linux"
+                }
+            ]
+        }
     ]
 }


### PR DESCRIPTION
this PR adds build setup for Linux as well as a simple cmake workflow preset for both os'es.

you can now configure, build and install in one command:

```
SC_SRC_PATH=/path/to/your/supercollider-sources cmake --workflow --preset PresetName
```

this will install into the local `install` folder within the repo which can then be symlinked to your user extensions folder.

Within the project root, on linux:

```
ln -s $pwd/install/SuperStecker ~/.local/share/SuperCollider/Extensions/SuperStecker
``` 

the target folder is different on macOS the procedure is the same.


The above could eventually just go into the README....