### PR TITLE
no trait, interface for room map analogous to HashMap

### DIFF
--- a/src/server/models.rs
+++ b/src/server/models.rs
@@ -158,13 +158,13 @@ pub enum AnyBroadcastRoom {
     ChatBroadcastRoom(BroadcastRoom<String>),
 }
 
-impl<T: Clone> Into<Room> for BroadcastRoom<T> {
-    fn into(self) -> Room {
-        Room {
-            uuid: self.uuid.to_string(),
-            name: self.name.to_string(),
+impl<T: Clone> From<BroadcastRoom<T>> for Room {
+    fn from(value: BroadcastRoom<T>) -> Self {
+        Self {
+            uuid: value.uuid.to_string(),
+            name: value.name.to_string(),
             num_listeners: 0,
-            room_type: self.room_type.into(),
+            room_type: value.room_type.into(),
         }
     }
 }

--- a/src/server/schema.rs
+++ b/src/server/schema.rs
@@ -15,8 +15,20 @@ impl Query {
         let state = ctx.data_unchecked::<AppState>();
 
         match room_type {
-            RoomType::Float => state.float_rooms.values().await,
-            RoomType::Chat => state.chat_rooms.values().await,
+            RoomType::Float => state
+                .float_rooms
+                .values()
+                .await
+                .into_iter()
+                .map(|r| r.into())
+                .collect(),
+            RoomType::Chat => state
+                .chat_rooms
+                .values()
+                .await
+                .into_iter()
+                .map(|a| a.into())
+                .collect(),
         }
     }
 }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -34,9 +34,9 @@ impl AppState {
     }
 }
 
-pub struct RoomMap<R: Into<Room> + Clone>(Mutex<HashMap<String, Arc<Mutex<R>>>>);
+pub struct RoomMap<R: Clone>(Mutex<HashMap<String, Arc<Mutex<R>>>>);
 
-impl<R: Into<Room> + Clone> RoomMap<R> {
+impl<R: Clone> RoomMap<R> {
     pub async fn clear(&self) {
         let mut map_lock = self.0.lock().await;
         *map_lock = HashMap::new();
@@ -54,14 +54,14 @@ impl<R: Into<Room> + Clone> RoomMap<R> {
         self.0.lock().await.contains_key(room_name)
     }
 
-    pub async fn values(&self) -> Vec<Room> {
+    pub async fn values(&self) -> Vec<R> {
         let map_lock = self.0.lock().await;
 
         let mut rooms = Vec::new();
 
         for (_, room_arc) in map_lock.iter() {
             let room_lock = room_arc.lock().await;
-            rooms.push((*room_lock).clone().into());
+            rooms.push((*room_lock).clone());
         }
         rooms
     }


### PR DESCRIPTION
simpler RoomMap without traits (still generic, but instead ob having the RoomMap depend on the data type, it just depends on a Into<Room> impl which BroadcastRoom has. this decouples the AppState map structure from the various data types the rooms use.